### PR TITLE
Write historical token_datas_v2, token_ownerships_v2 and fungible_asset_balances to Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,6 +3516,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.10.8",
  "sha3",
  "strum",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,57 @@ If you want to index a custom contract, we recommend using the [Quickstart Guide
 - `processor_config`
     - `type`: which processor to run
     - `channel_size`: size of channel in between steps
+    - `tables_to_write`: which tables this processor writes. See [Selecting tables to write](#selecting-tables-to-write) below.
     - Some processors require additional configuration. See the full list of configs [here](./processor/src/config/processor_config.rs#L102).
+
+##### Selecting tables to write
+
+`tables_to_write` takes Postgres table names, matched case-insensitively. Unrecognized names are skipped with a warning rather than failing startup, so check the logs if a table is unexpectedly empty.
+
+- **Omitted or empty**: every table the processor supports, except the opt-in-only ones below.
+- **Non-empty**: an allowlist -- only the tables you name are written. Anything you leave out is silently *not* written, so list every table you want.
+
+Each processor logs its effective selection at startup (`Writing all default tables for this processor; ...`), which is the quickest way to confirm a config does what you meant.
+
+###### Opt-in-only tables
+
+Three historical tables are **not** written unless you name them explicitly:
+
+| Table | Processor |
+|---|---|
+| `fungible_asset_balances` | `fungible_asset_processor` |
+| `token_datas_v2` | `token_v2_processor` |
+| `token_ownerships_v2` | `token_v2_processor` |
+
+They hold one row per write set change rather than one row per entity, so they grow much faster than their `current_` counterparts -- size storage accordingly before enabling them.
+
+Naming an opt-in-only table does **not** turn `tables_to_write` into an allowlist for everything else. This enables the two historical tables while leaving every other `token_v2_processor` table on:
+
+```yaml
+processor_config:
+  type: token_v2_processor
+  tables_to_write:
+    - token_datas_v2
+    - token_ownerships_v2
+```
+
+To restrict to an explicit set instead, list all the tables you want:
+
+```yaml
+processor_config:
+  type: token_v2_processor
+  tables_to_write:
+    - current_token_datas_v2
+    - current_token_ownerships_v2
+    - token_datas_v2
+```
+
+Caveats when enabling these:
+
+- **No backfill.** Rows only start appearing from the version the processor is at when you enable the flag. Inserts use `ON CONFLICT ... DO NOTHING`, so replaying earlier versions will not fill in or correct history you missed.
+- **`token_datas_v2.is_deleted_v2` is always `NULL`.** Burns are only recorded in `current_token_datas_v2`; no historical row is emitted for them. Do not use `token_datas_v2` alone to determine whether a token still exists.
+- **The `legacy_migration_v1` views stay incomplete.** `legacy_migration_v1.coin_balances` reads `fungible_asset_balances` directly, so it will start returning *partial* history -- data covering only the period since you enabled the flag. The token views (`legacy_migration_v1.token_ownerships`, `token_activities`) join `collections_v2`, which no Postgres processor writes, so they continue to return zero rows.
+- **Supporting indexes are not created.** The indexes these tables need for the legacy views are commented out in [the migration](./processor/src/db/migrations/2024-05-22-200847_add_v1_migration_views/up.sql) because they must be built `CONCURRENTLY` outside of diesel. Create them before querying at any scale.
 
 - `processor_mode`: The processor can be run in these modes:
     - Default (bootstrap) mode: On first run, the processor will start from `initial_starting_version`. Upon restart, the processor continues from `processor_status.last_success_version` saved in DB. 

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -85,3 +85,4 @@ jemallocator = { version = "0.5.0", features = [
 aptos-indexer-processor-sdk = { workspace = true, features = [
     "testing_framework",
 ] }
+serde_yaml = { workspace = true }

--- a/processor/src/config/processor_config.rs
+++ b/processor/src/config/processor_config.rs
@@ -326,6 +326,31 @@ impl ParquetDefaultProcessorConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::table_flags::TableFlags;
+
+    #[test]
+    fn test_tables_to_write_parses_at_processor_config_level() {
+        // Mirrors the shape documented in processor/local-config.yaml: `tables_to_write`
+        // sits alongside `type`, since DefaultProcessorConfig is flattened into the
+        // per-processor configs.
+        let yaml = r#"
+type: token_v2_processor
+channel_size: 100
+tables_to_write:
+  - token_datas_v2
+  - token_ownerships_v2
+"#;
+        let config: ProcessorConfig = serde_yaml::from_str(yaml).unwrap();
+        let ProcessorConfig::TokenV2Processor(token_v2_config) = &config else {
+            panic!("expected a token_v2_processor config, got {config:?}");
+        };
+
+        let flags = TableFlags::from_set(&token_v2_config.default_config.tables_to_write);
+        assert_eq!(
+            flags,
+            TableFlags::TOKEN_DATAS_V2 | TableFlags::TOKEN_OWNERSHIPS_V2
+        );
+    }
 
     #[test]
     fn test_valid_table_names() {

--- a/processor/src/processors/fungible_asset/fungible_asset_extractor.rs
+++ b/processor/src/processors/fungible_asset/fungible_asset_extractor.rs
@@ -1,17 +1,20 @@
-use crate::processors::fungible_asset::{
-    coin_models::coin_supply::CoinSupply,
-    fungible_asset_models::{
-        v2_fungible_asset_activities::PostgresFungibleAssetActivity,
-        v2_fungible_asset_balances::{
-            PostgresCurrentUnifiedFungibleAssetBalance, PostgresFungibleAssetBalance,
+use crate::{
+    processors::fungible_asset::{
+        coin_models::coin_supply::CoinSupply,
+        fungible_asset_models::{
+            v2_fungible_asset_activities::PostgresFungibleAssetActivity,
+            v2_fungible_asset_balances::{
+                PostgresCurrentUnifiedFungibleAssetBalance, PostgresFungibleAssetBalance,
+            },
+            v2_fungible_asset_to_coin_mappings::{
+                FungibleAssetToCoinMapping, FungibleAssetToCoinMappings,
+                PostgresFungibleAssetToCoinMapping,
+            },
+            v2_fungible_metadata::PostgresFungibleAssetMetadataModel,
         },
-        v2_fungible_asset_to_coin_mappings::{
-            FungibleAssetToCoinMapping, FungibleAssetToCoinMappings,
-            PostgresFungibleAssetToCoinMapping,
-        },
-        v2_fungible_metadata::PostgresFungibleAssetMetadataModel,
+        fungible_asset_processor_helpers::{get_fa_to_coin_mapping, parse_v2_coin},
     },
-    fungible_asset_processor_helpers::{get_fa_to_coin_mapping, parse_v2_coin},
+    utils::table_flags::{should_write, TableFlags},
 };
 use ahash::AHashMap;
 use anyhow::Result;
@@ -30,12 +33,14 @@ where
     Self: Sized + Send + 'static,
 {
     pub fa_to_coin_mapping: FungibleAssetToCoinMappings,
+    tables_to_write: TableFlags,
 }
 
 impl FungibleAssetExtractor {
-    pub fn new() -> Self {
+    pub fn new(tables_to_write: TableFlags) -> Self {
         Self {
             fa_to_coin_mapping: AHashMap::new(),
+            tables_to_write,
         }
     }
 
@@ -56,7 +61,7 @@ impl FungibleAssetExtractor {
 
 impl Default for FungibleAssetExtractor {
     fn default() -> Self {
-        Self::new()
+        Self::new(TableFlags::empty())
     }
 }
 
@@ -119,11 +124,17 @@ impl Processable for FungibleAssetExtractor {
                 .map(PostgresFungibleAssetMetadataModel::from)
                 .collect();
 
+        // Opt-in only, so don't pay to convert rows the storer would discard -- they would
+        // otherwise stay alive in the channel for every in-flight batch.
         let postgres_fungible_asset_balances: Vec<PostgresFungibleAssetBalance> =
-            raw_fungible_asset_balances
-                .into_iter()
-                .map(PostgresFungibleAssetBalance::from)
-                .collect();
+            if should_write(&self.tables_to_write, TableFlags::FUNGIBLE_ASSET_BALANCES) {
+                raw_fungible_asset_balances
+                    .into_iter()
+                    .map(PostgresFungibleAssetBalance::from)
+                    .collect()
+            } else {
+                vec![]
+            };
 
         let postgres_current_unified_fab_v1: Vec<PostgresCurrentUnifiedFungibleAssetBalance> =
             raw_current_unified_fab_v1

--- a/processor/src/processors/fungible_asset/fungible_asset_processor.rs
+++ b/processor/src/processors/fungible_asset/fungible_asset_processor.rs
@@ -126,6 +126,11 @@ impl ProcessorTrait for FungibleAssetProcessor {
         };
         let channel_size = processor_config.channel_size;
         let deprecated_table_flags = TableFlags::from_set(&processor_config.tables_to_write);
+        info!(
+            processor = self.name(),
+            "Writing {}",
+            deprecated_table_flags.describe_effective()
+        );
 
         // Define processor steps
         let transaction_stream = TransactionStreamStep::new(TransactionStreamConfig {
@@ -135,7 +140,7 @@ impl ProcessorTrait for FungibleAssetProcessor {
         })
         .await?;
 
-        let mut fa_extractor = FungibleAssetExtractor::new();
+        let mut fa_extractor = FungibleAssetExtractor::new(deprecated_table_flags);
         fa_extractor
             .bootstrap_fa_to_coin_mapping(self.db_pool.clone())
             .await?;

--- a/processor/src/processors/fungible_asset/fungible_asset_storer.rs
+++ b/processor/src/processors/fungible_asset/fungible_asset_storer.rs
@@ -92,7 +92,7 @@ impl Processable for FungibleAssetStorer {
         let (
             fungible_asset_activities,
             fungible_asset_metadata,
-            _,
+            fungible_asset_balances,
             (current_unified_fab_v1, current_unified_fab_v2),
             _,
             fa_to_coin_mappings,
@@ -106,12 +106,14 @@ impl Processable for FungibleAssetStorer {
             current_unified_fab_v2,
             fungible_asset_activities,
             fungible_asset_metadata,
+            fungible_asset_balances,
             fa_to_coin_mappings,
         ) = filter_datasets!(self, {
             current_unified_fab_v1 => TableFlags::CURRENT_FUNGIBLE_ASSET_BALANCES,
             current_unified_fab_v2 => TableFlags::CURRENT_FUNGIBLE_ASSET_BALANCES,
             fungible_asset_activities => TableFlags::FUNGIBLE_ASSET_ACTIVITIES,
             fungible_asset_metadata => TableFlags::FUNGIBLE_ASSET_METADATA,
+            fungible_asset_balances => TableFlags::FUNGIBLE_ASSET_BALANCES,
             fa_to_coin_mappings => TableFlags::FUNGIBLE_ASSET_TO_COIN_MAPPINGS,
         });
 
@@ -151,6 +153,15 @@ impl Processable for FungibleAssetStorer {
                 &per_table_chunk_sizes,
             ),
         );
+        let fab = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_fungible_asset_balances_query,
+            &fungible_asset_balances,
+            get_config_table_chunk_size::<PostgresFungibleAssetBalance>(
+                "fungible_asset_balances",
+                &per_table_chunk_sizes,
+            ),
+        );
         let fatcm = execute_in_chunks(
             self.conn_pool.clone(),
             insert_fungible_asset_to_coin_mappings_query,
@@ -160,9 +171,9 @@ impl Processable for FungibleAssetStorer {
                 &per_table_chunk_sizes,
             ),
         );
-        let (faa_res, fam_res, cufab1_res, cufab2_res, fatcm_res) =
-            tokio::join!(faa, fam, cufab_v1, cufab_v2, fatcm);
-        for res in [faa_res, fam_res, cufab1_res, cufab2_res, fatcm_res] {
+        let (faa_res, fam_res, fab_res, cufab1_res, cufab2_res, fatcm_res) =
+            tokio::join!(faa, fam, fab, cufab_v1, cufab_v2, fatcm);
+        for res in [faa_res, fam_res, fab_res, cufab1_res, cufab2_res, fatcm_res] {
             match res {
                 Ok(_) => {},
                 Err(e) => {

--- a/processor/src/processors/token_v2/token_v2_extractor.rs
+++ b/processor/src/processors/token_v2/token_v2_extractor.rs
@@ -1,15 +1,18 @@
-use crate::processors::token_v2::{
-    token_models::{
-        token_claims::PostgresCurrentTokenPendingClaim,
-        token_royalty::PostgresCurrentTokenRoyaltyV1, tokens::TableMetadataForToken,
+use crate::{
+    processors::token_v2::{
+        token_models::{
+            token_claims::PostgresCurrentTokenPendingClaim,
+            token_royalty::PostgresCurrentTokenRoyaltyV1, tokens::TableMetadataForToken,
+        },
+        token_v2_models::{
+            v2_collections::CurrentCollectionV2,
+            v2_token_activities::PostgresTokenActivityV2,
+            v2_token_datas::{PostgresCurrentTokenDataV2, PostgresTokenDataV2},
+            v2_token_ownerships::{PostgresCurrentTokenOwnershipV2, PostgresTokenOwnershipV2},
+        },
+        token_v2_processor_helpers::parse_v2_token,
     },
-    token_v2_models::{
-        v2_collections::CurrentCollectionV2,
-        v2_token_activities::PostgresTokenActivityV2,
-        v2_token_datas::{PostgresCurrentTokenDataV2, PostgresTokenDataV2},
-        v2_token_ownerships::{PostgresCurrentTokenOwnershipV2, PostgresTokenOwnershipV2},
-    },
-    token_v2_processor_helpers::parse_v2_token,
+    utils::table_flags::{should_write, TableFlags},
 };
 use aptos_indexer_processor_sdk::{
     aptos_protos::transaction::v1::Transaction,
@@ -28,15 +31,29 @@ where
     query_retries: u32,
     query_retry_delay_ms: u64,
     conn_pool: ArcDbPool,
+    tables_to_write: TableFlags,
 }
 
 impl TokenV2Extractor {
-    pub fn new(query_retries: u32, query_retry_delay_ms: u64, conn_pool: ArcDbPool) -> Self {
+    pub fn new(
+        query_retries: u32,
+        query_retry_delay_ms: u64,
+        conn_pool: ArcDbPool,
+        tables_to_write: TableFlags,
+    ) -> Self {
         Self {
             query_retries,
             query_retry_delay_ms,
             conn_pool,
+            tables_to_write,
         }
+    }
+
+    /// The historical (non-current) tables are opt-in. Converting their rows only to have
+    /// the storer drop them would keep a full batch of them alive in the channel for every
+    /// in-flight batch, so skip the conversion entirely when the table is disabled.
+    fn wants(&self, flag: TableFlags) -> bool {
+        should_write(&self.tables_to_write, flag)
     }
 }
 
@@ -157,15 +174,25 @@ impl Processable for TokenV2Extractor {
                 .map(PostgresCurrentTokenOwnershipV2::from)
                 .collect();
 
-        let postgres_token_datas_v2: Vec<PostgresTokenDataV2> = raw_token_datas_v2
-            .into_iter()
-            .map(PostgresTokenDataV2::from)
-            .collect();
+        let postgres_token_datas_v2: Vec<PostgresTokenDataV2> =
+            if self.wants(TableFlags::TOKEN_DATAS_V2) {
+                raw_token_datas_v2
+                    .into_iter()
+                    .map(PostgresTokenDataV2::from)
+                    .collect()
+            } else {
+                vec![]
+            };
 
-        let postgres_token_ownerships_v2: Vec<PostgresTokenOwnershipV2> = raw_token_ownerships_v2
-            .into_iter()
-            .map(PostgresTokenOwnershipV2::from)
-            .collect();
+        let postgres_token_ownerships_v2: Vec<PostgresTokenOwnershipV2> =
+            if self.wants(TableFlags::TOKEN_OWNERSHIPS_V2) {
+                raw_token_ownerships_v2
+                    .into_iter()
+                    .map(PostgresTokenOwnershipV2::from)
+                    .collect()
+            } else {
+                vec![]
+            };
 
         Ok(Some(TransactionContext {
             data: (

--- a/processor/src/processors/token_v2/token_v2_extractor.rs
+++ b/processor/src/processors/token_v2/token_v2_extractor.rs
@@ -4,9 +4,10 @@ use crate::processors::token_v2::{
         token_royalty::PostgresCurrentTokenRoyaltyV1, tokens::TableMetadataForToken,
     },
     token_v2_models::{
-        v2_collections::CurrentCollectionV2, v2_token_activities::PostgresTokenActivityV2,
-        v2_token_datas::PostgresCurrentTokenDataV2,
-        v2_token_ownerships::PostgresCurrentTokenOwnershipV2,
+        v2_collections::CurrentCollectionV2,
+        v2_token_activities::PostgresTokenActivityV2,
+        v2_token_datas::{PostgresCurrentTokenDataV2, PostgresTokenDataV2},
+        v2_token_ownerships::{PostgresCurrentTokenOwnershipV2, PostgresTokenOwnershipV2},
     },
     token_v2_processor_helpers::parse_v2_token,
 };
@@ -51,6 +52,8 @@ impl Processable for TokenV2Extractor {
         Vec<PostgresTokenActivityV2>,
         Vec<PostgresCurrentTokenRoyaltyV1>,
         Vec<PostgresCurrentTokenPendingClaim>,
+        Vec<PostgresTokenDataV2>,
+        Vec<PostgresTokenOwnershipV2>,
     );
     type RunType = AsyncRunType;
 
@@ -68,6 +71,8 @@ impl Processable for TokenV2Extractor {
                 Vec<PostgresTokenActivityV2>,
                 Vec<PostgresCurrentTokenRoyaltyV1>,
                 Vec<PostgresCurrentTokenPendingClaim>,
+                Vec<PostgresTokenDataV2>,
+                Vec<PostgresTokenOwnershipV2>,
             )>,
         >,
         ProcessorError,
@@ -91,12 +96,10 @@ impl Processable for TokenV2Extractor {
             query_retry_delay_ms: self.query_retry_delay_ms,
         };
 
-        // Token v2 processor only writes to current tables. If you need to write to non-current
-        // tables, modify TokenV2Storer step to include the tables you want to write to.
         let (
             _,
-            _,
-            _,
+            raw_token_datas_v2,
+            raw_token_ownerships_v2,
             current_collections_v2,
             raw_current_token_datas_v2,
             raw_current_deleted_token_datas_v2,
@@ -154,6 +157,16 @@ impl Processable for TokenV2Extractor {
                 .map(PostgresCurrentTokenOwnershipV2::from)
                 .collect();
 
+        let postgres_token_datas_v2: Vec<PostgresTokenDataV2> = raw_token_datas_v2
+            .into_iter()
+            .map(PostgresTokenDataV2::from)
+            .collect();
+
+        let postgres_token_ownerships_v2: Vec<PostgresTokenOwnershipV2> = raw_token_ownerships_v2
+            .into_iter()
+            .map(PostgresTokenOwnershipV2::from)
+            .collect();
+
         Ok(Some(TransactionContext {
             data: (
                 current_collections_v2,
@@ -164,6 +177,8 @@ impl Processable for TokenV2Extractor {
                 postgres_token_activities_v2,
                 postgres_current_token_royalties_v1,
                 postgres_current_token_claims,
+                postgres_token_datas_v2,
+                postgres_token_ownerships_v2,
             ),
             metadata: transactions.metadata,
         }))

--- a/processor/src/processors/token_v2/token_v2_models/v2_token_datas.rs
+++ b/processor/src/processors/token_v2/token_v2_models/v2_token_datas.rs
@@ -17,7 +17,7 @@ use crate::{
             },
         },
     },
-    schema::current_token_datas_v2,
+    schema::{current_token_datas_v2, token_datas_v2},
 };
 use allocative_derive::Allocative;
 use anyhow::Context;
@@ -423,6 +423,54 @@ impl From<CurrentTokenDataV2> for ParquetCurrentTokenDataV2 {
 
 // PK of current_token_datas_v2, i.e. token_data_id
 pub type CurrentTokenDataV2PK = String;
+
+/// This is the postgres version of TokenDataV2, i.e. the historical (non-current) table
+/// with one row per write set change.
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, write_set_change_index))]
+#[diesel(table_name = token_datas_v2)]
+pub struct PostgresTokenDataV2 {
+    pub transaction_version: i64,
+    pub write_set_change_index: i64,
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub maximum: Option<BigDecimal>,
+    pub supply: Option<BigDecimal>,
+    pub largest_property_version_v1: Option<BigDecimal>,
+    pub token_uri: String,
+    pub token_properties: serde_json::Value,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+    // Deprecated, but still here for backwards compatibility
+    pub decimals: Option<i64>,
+    pub is_deleted_v2: Option<bool>,
+}
+
+impl From<TokenDataV2> for PostgresTokenDataV2 {
+    fn from(raw_item: TokenDataV2) -> Self {
+        Self {
+            transaction_version: raw_item.transaction_version,
+            write_set_change_index: raw_item.write_set_change_index,
+            token_data_id: raw_item.token_data_id,
+            collection_id: raw_item.collection_id,
+            token_name: raw_item.token_name,
+            maximum: raw_item.maximum,
+            supply: raw_item.supply,
+            largest_property_version_v1: raw_item.largest_property_version_v1,
+            token_uri: raw_item.token_uri,
+            token_properties: raw_item.token_properties,
+            description: raw_item.description,
+            token_standard: raw_item.token_standard,
+            is_fungible_v2: raw_item.is_fungible_v2,
+            transaction_timestamp: raw_item.transaction_timestamp,
+            decimals: raw_item.decimals,
+            is_deleted_v2: raw_item.is_deleted_v2,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(token_data_id))]

--- a/processor/src/processors/token_v2/token_v2_models/v2_token_ownerships.rs
+++ b/processor/src/processors/token_v2/token_v2_models/v2_token_ownerships.rs
@@ -25,7 +25,7 @@ use crate::{
             },
         },
     },
-    schema::current_token_ownerships_v2,
+    schema::{current_token_ownerships_v2, token_ownerships_v2},
 };
 use ahash::AHashMap;
 use allocative_derive::Allocative;
@@ -773,6 +773,51 @@ impl From<CurrentTokenOwnershipV2> for ParquetCurrentTokenOwnershipV2 {
             is_fungible_v2: raw_item.is_fungible_v2,
             last_transaction_version: raw_item.last_transaction_version,
             last_transaction_timestamp: raw_item.last_transaction_timestamp,
+            non_transferrable_by_owner: raw_item.non_transferrable_by_owner,
+        }
+    }
+}
+
+/// This is the postgres version of TokenOwnershipV2, i.e. the historical (non-current) table
+/// with one row per write set change.
+#[derive(
+    Clone, Debug, Deserialize, Eq, FieldCount, Identifiable, Insertable, PartialEq, Serialize,
+)]
+#[diesel(primary_key(transaction_version, write_set_change_index))]
+#[diesel(table_name = token_ownerships_v2)]
+pub struct PostgresTokenOwnershipV2 {
+    pub transaction_version: i64,
+    pub write_set_change_index: i64,
+    pub token_data_id: String,
+    pub property_version_v1: BigDecimal,
+    pub owner_address: Option<String>,
+    pub storage_id: String,
+    pub amount: BigDecimal,
+    pub table_type_v1: Option<String>,
+    pub token_properties_mutated_v1: Option<serde_json::Value>,
+    pub is_soulbound_v2: Option<bool>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+    pub non_transferrable_by_owner: Option<bool>,
+}
+
+impl From<TokenOwnershipV2> for PostgresTokenOwnershipV2 {
+    fn from(raw_item: TokenOwnershipV2) -> Self {
+        Self {
+            transaction_version: raw_item.transaction_version,
+            write_set_change_index: raw_item.write_set_change_index,
+            token_data_id: raw_item.token_data_id,
+            property_version_v1: raw_item.property_version_v1,
+            owner_address: raw_item.owner_address,
+            storage_id: raw_item.storage_id,
+            amount: raw_item.amount,
+            table_type_v1: raw_item.table_type_v1,
+            token_properties_mutated_v1: raw_item.token_properties_mutated_v1,
+            is_soulbound_v2: raw_item.is_soulbound_v2,
+            token_standard: raw_item.token_standard,
+            is_fungible_v2: raw_item.is_fungible_v2,
+            transaction_timestamp: raw_item.transaction_timestamp,
             non_transferrable_by_owner: raw_item.non_transferrable_by_owner,
         }
     }

--- a/processor/src/processors/token_v2/token_v2_processor.rs
+++ b/processor/src/processors/token_v2/token_v2_processor.rs
@@ -129,12 +129,18 @@ impl ProcessorTrait for TokenV2Processor {
             ..self.config.transaction_stream_config.clone()
         })
         .await?;
+        let opt_in_tables = TableFlags::from_set(&processor_config.default_config.tables_to_write);
+        info!(
+            processor = self.name(),
+            "Writing {}",
+            opt_in_tables.describe_effective()
+        );
         let token_v2_extractor = TokenV2Extractor::new(
             processor_config.query_retries,
             processor_config.query_retry_delay_ms,
             self.db_pool.clone(),
+            opt_in_tables,
         );
-        let opt_in_tables = TableFlags::from_set(&processor_config.default_config.tables_to_write);
         let token_v2_storer = TokenV2Storer::new(
             self.db_pool.clone(),
             processor_config.clone(),

--- a/processor/src/processors/token_v2/token_v2_processor_queries.rs
+++ b/processor/src/processors/token_v2/token_v2_processor_queries.rs
@@ -8,9 +8,10 @@ use crate::{
             token_royalty::PostgresCurrentTokenRoyaltyV1,
         },
         token_v2_models::{
-            v2_collections::CurrentCollectionV2, v2_token_activities::PostgresTokenActivityV2,
-            v2_token_datas::PostgresCurrentTokenDataV2,
-            v2_token_ownerships::PostgresCurrentTokenOwnershipV2,
+            v2_collections::CurrentCollectionV2,
+            v2_token_activities::PostgresTokenActivityV2,
+            v2_token_datas::{PostgresCurrentTokenDataV2, PostgresTokenDataV2},
+            v2_token_ownerships::{PostgresCurrentTokenOwnershipV2, PostgresTokenOwnershipV2},
         },
     },
     schema,
@@ -49,6 +50,28 @@ pub fn insert_current_collections_v2_query(
             inserted_at.eq(excluded(inserted_at)),
         ))
         .filter(last_transaction_version.le(excluded(last_transaction_version)))
+}
+
+pub fn insert_token_datas_v2_query(
+    items_to_insert: Vec<PostgresTokenDataV2>,
+) -> impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send {
+    use schema::token_datas_v2::dsl::*;
+
+    diesel::insert_into(schema::token_datas_v2::table)
+        .values(items_to_insert)
+        .on_conflict((transaction_version, write_set_change_index))
+        .do_nothing()
+}
+
+pub fn insert_token_ownerships_v2_query(
+    items_to_insert: Vec<PostgresTokenOwnershipV2>,
+) -> impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send {
+    use schema::token_ownerships_v2::dsl::*;
+
+    diesel::insert_into(schema::token_ownerships_v2::table)
+        .values(items_to_insert)
+        .on_conflict((transaction_version, write_set_change_index))
+        .do_nothing()
 }
 
 pub fn insert_current_token_datas_v2_query(

--- a/processor/src/processors/token_v2/token_v2_storer.rs
+++ b/processor/src/processors/token_v2/token_v2_storer.rs
@@ -6,9 +6,10 @@ use crate::{
             token_royalty::PostgresCurrentTokenRoyaltyV1,
         },
         token_v2_models::{
-            v2_collections::CurrentCollectionV2, v2_token_activities::PostgresTokenActivityV2,
-            v2_token_datas::PostgresCurrentTokenDataV2,
-            v2_token_ownerships::PostgresCurrentTokenOwnershipV2,
+            v2_collections::CurrentCollectionV2,
+            v2_token_activities::PostgresTokenActivityV2,
+            v2_token_datas::{PostgresCurrentTokenDataV2, PostgresTokenDataV2},
+            v2_token_ownerships::{PostgresCurrentTokenOwnershipV2, PostgresTokenOwnershipV2},
         },
         token_v2_processor::TokenV2ProcessorConfig,
         token_v2_processor_queries::{
@@ -16,6 +17,7 @@ use crate::{
             insert_current_deleted_token_ownerships_v2_query, insert_current_token_claims_query,
             insert_current_token_datas_v2_query, insert_current_token_ownerships_v2_query,
             insert_current_token_royalties_v1_query, insert_token_activities_v2_query,
+            insert_token_datas_v2_query, insert_token_ownerships_v2_query,
         },
     },
     utils::table_flags::{filter_data, TableFlags},
@@ -65,6 +67,8 @@ impl Processable for TokenV2Storer {
         Vec<PostgresTokenActivityV2>,
         Vec<PostgresCurrentTokenRoyaltyV1>,
         Vec<PostgresCurrentTokenPendingClaim>,
+        Vec<PostgresTokenDataV2>,
+        Vec<PostgresTokenOwnershipV2>,
     );
     type Output = ();
     type RunType = AsyncRunType;
@@ -80,6 +84,8 @@ impl Processable for TokenV2Storer {
             Vec<PostgresTokenActivityV2>,
             Vec<PostgresCurrentTokenRoyaltyV1>,
             Vec<PostgresCurrentTokenPendingClaim>,
+            Vec<PostgresTokenDataV2>,
+            Vec<PostgresTokenOwnershipV2>,
         )>,
     ) -> Result<Option<TransactionContext<Self::Output>>, ProcessorError> {
         let (
@@ -91,6 +97,8 @@ impl Processable for TokenV2Storer {
             token_activities_v2,
             current_token_royalties_v1,
             current_token_claims,
+            token_datas_v2,
+            token_ownerships_v2,
         ) = input.data;
 
         let (
@@ -102,6 +110,8 @@ impl Processable for TokenV2Storer {
             token_activities_v2,
             current_token_royalties_v1,
             current_token_claims,
+            token_datas_v2,
+            token_ownerships_v2,
         ) = filter_datasets!(self, {
             current_collections_v2 => TableFlags::CURRENT_COLLECTIONS_V2,
             current_token_datas_v2 => TableFlags::CURRENT_TOKEN_DATAS_V2,
@@ -111,6 +121,8 @@ impl Processable for TokenV2Storer {
             token_activities_v2 => TableFlags::TOKEN_ACTIVITIES_V2,
             current_token_royalties_v1 => TableFlags::CURRENT_TOKEN_ROYALTY_V1,
             current_token_claims => TableFlags::CURRENT_TOKEN_PENDING_CLAIMS,
+            token_datas_v2 => TableFlags::TOKEN_DATAS_V2,
+            token_ownerships_v2 => TableFlags::TOKEN_OWNERSHIPS_V2,
         });
 
         let per_table_chunk_sizes: AHashMap<String, usize> = self
@@ -192,6 +204,25 @@ impl Processable for TokenV2Storer {
             ),
         );
 
+        let td_v2 = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_token_datas_v2_query,
+            &token_datas_v2,
+            get_config_table_chunk_size::<PostgresTokenDataV2>(
+                "token_datas_v2",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let to_v2 = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_token_ownerships_v2_query,
+            &token_ownerships_v2,
+            get_config_table_chunk_size::<PostgresTokenOwnershipV2>(
+                "token_ownerships_v2",
+                &per_table_chunk_sizes,
+            ),
+        );
+
         let (
             cc_v2_res,
             ctd_v2_res,
@@ -201,7 +232,11 @@ impl Processable for TokenV2Storer {
             ta_v2_res,
             ctr_v1_res,
             ctc_v1_res,
-        ) = tokio::join!(cc_v2, ctd_v2, cdtd_v2, cto_v2, cdto_v2, ta_v2, ctr_v1, ctc_v1);
+            td_v2_res,
+            to_v2_res,
+        ) = tokio::join!(
+            cc_v2, ctd_v2, cdtd_v2, cto_v2, cdto_v2, ta_v2, ctr_v1, ctc_v1, td_v2, to_v2
+        );
 
         for res in [
             cc_v2_res,
@@ -212,6 +247,8 @@ impl Processable for TokenV2Storer {
             ta_v2_res,
             ctr_v1_res,
             ctc_v1_res,
+            td_v2_res,
+            to_v2_res,
         ] {
             match res {
                 Ok(_) => {},

--- a/processor/src/utils/table_flags.rs
+++ b/processor/src/utils/table_flags.rs
@@ -116,6 +116,28 @@ impl TableFlags {
         }
         flags
     }
+
+    /// Human readable summary of what this config actually writes, for logging at startup.
+    ///
+    /// `tables_to_write` is easy to get subtly wrong -- an allowlist silently suppresses
+    /// everything it omits, and a name belonging to a different processor suppresses
+    /// everything. Emitting this once at boot makes the effective set visible instead of
+    /// leaving operators to infer it from missing rows.
+    pub fn describe_effective(&self) -> String {
+        let allowlist = self.difference(TableFlags::OPT_IN_ONLY);
+        let opted_in = self.intersection(TableFlags::OPT_IN_ONLY);
+
+        let base = if allowlist.is_empty() {
+            "all default tables for this processor".to_string()
+        } else {
+            format!("only these tables: {allowlist:?}")
+        };
+        if opted_in.is_empty() {
+            format!("{base}; no opt-in-only tables enabled")
+        } else {
+            format!("{base}; plus opt-in-only tables: {opted_in:?}")
+        }
+    }
 }
 
 /**
@@ -129,21 +151,23 @@ impl TableFlags {
  * every table that used to be written by default.
  */
 pub fn filter_data<T>(tables_to_write: &TableFlags, flag: TableFlags, data: Vec<T>) -> Vec<T> {
-    if TableFlags::OPT_IN_ONLY.contains(flag) {
-        return if tables_to_write.contains(flag) {
-            data
-        } else {
-            vec![]
-        };
-    }
-
-    // Opt-in names don't count towards "did the operator specify an allowlist?".
-    let allowlist = tables_to_write.difference(TableFlags::OPT_IN_ONLY);
-    if allowlist.is_empty() || allowlist.contains(flag) {
+    if should_write(tables_to_write, flag) {
         data
     } else {
         vec![]
     }
+}
+
+/// Whether `flag`'s table is written under this config. Extractors use this to skip building
+/// rows they know the storer would discard; `filter_data` uses it to do the discarding.
+pub fn should_write(tables_to_write: &TableFlags, flag: TableFlags) -> bool {
+    if TableFlags::OPT_IN_ONLY.contains(flag) {
+        return tables_to_write.contains(flag);
+    }
+
+    // Opt-in names don't count towards "did the operator specify an allowlist?".
+    let allowlist = tables_to_write.difference(TableFlags::OPT_IN_ONLY);
+    allowlist.is_empty() || allowlist.contains(flag)
 }
 
 /// Macro to filter multiple data sets with their corresponding table flags in one go
@@ -207,6 +231,21 @@ mod tests {
         );
         // A sibling opt-in table stays off.
         assert!(filter_data(&flags, TableFlags::TOKEN_OWNERSHIPS_V2, vec![1]).is_empty());
+    }
+
+    #[test]
+    fn describe_effective_distinguishes_default_allowlist_and_opt_in() {
+        let default = TableFlags::empty().describe_effective();
+        assert!(default.contains("all default tables"), "{default}");
+        assert!(default.contains("no opt-in-only"), "{default}");
+
+        let opted_in = TableFlags::from_set(&set(&["token_datas_v2"])).describe_effective();
+        assert!(opted_in.contains("all default tables"), "{opted_in}");
+        assert!(opted_in.contains("TOKEN_DATAS_V2"), "{opted_in}");
+
+        let allowlist = TableFlags::from_set(&set(&["current_objects"])).describe_effective();
+        assert!(allowlist.contains("only these tables"), "{allowlist}");
+        assert!(allowlist.contains("CURRENT_OBJECTS"), "{allowlist}");
     }
 
     #[test]

--- a/processor/src/utils/table_flags.rs
+++ b/processor/src/utils/table_flags.rs
@@ -1,5 +1,6 @@
 use bitflags::bitflags;
 use std::collections::HashSet;
+use tracing::warn;
 
 bitflags! {
     #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -90,11 +91,27 @@ bitflags! {
 }
 
 impl TableFlags {
+    /// Tables that are NOT written unless they are named explicitly in `tables_to_write`.
+    ///
+    /// These are historical (non-current) tables holding one row per write set change, so
+    /// they grow far faster than their `current_` counterparts. Leaving them off by default
+    /// keeps existing deployments' storage profile unchanged; opt in per deployment.
+    pub const OPT_IN_ONLY: Self = Self::TOKEN_DATAS_V2
+        .union(Self::TOKEN_OWNERSHIPS_V2)
+        .union(Self::FUNGIBLE_ASSET_BALANCES);
+
+    /// Builds flags from the `tables_to_write` config entries. Names are matched
+    /// case-insensitively so configs can use natural table names (`token_datas_v2`) rather
+    /// than the uppercase flag names. Unrecognized names are skipped with a warning.
     pub fn from_set(set: &HashSet<String>) -> Self {
         let mut flags = TableFlags::empty();
         for table in set {
-            if let Some(flag) = TableFlags::from_name(table) {
-                flags |= flag;
+            match TableFlags::from_name(&table.to_uppercase()) {
+                Some(flag) => flags |= flag,
+                None => warn!(
+                    table_name = table.as_str(),
+                    "Unrecognized table name in tables_to_write, ignoring it"
+                ),
             }
         }
         flags
@@ -105,9 +122,24 @@ impl TableFlags {
  * This is a helper function to filter data based on the tables_to_write set.
  * If the tables_to_write set is empty or contains the flag, return the data so that they are written to the database.
  * Otherwise, return an empty vector so that they are not written to the database.
+ *
+ * Tables in `TableFlags::OPT_IN_ONLY` invert this: they are only written when named
+ * explicitly, and naming one does not turn `tables_to_write` into an allowlist for
+ * everything else. That way opting into a historical table doesn't silently switch off
+ * every table that used to be written by default.
  */
 pub fn filter_data<T>(tables_to_write: &TableFlags, flag: TableFlags, data: Vec<T>) -> Vec<T> {
-    if tables_to_write.is_empty() || tables_to_write.contains(flag) {
+    if TableFlags::OPT_IN_ONLY.contains(flag) {
+        return if tables_to_write.contains(flag) {
+            data
+        } else {
+            vec![]
+        };
+    }
+
+    // Opt-in names don't count towards "did the operator specify an allowlist?".
+    let allowlist = tables_to_write.difference(TableFlags::OPT_IN_ONLY);
+    if allowlist.is_empty() || allowlist.contains(flag) {
         data
     } else {
         vec![]
@@ -124,4 +156,70 @@ macro_rules! filter_datasets {
             )*
         )
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn from_set_accepts_lowercase_table_names() {
+        assert_eq!(
+            TableFlags::from_set(&set(&["token_datas_v2", "CURRENT_OBJECTS"])),
+            TableFlags::TOKEN_DATAS_V2 | TableFlags::CURRENT_OBJECTS
+        );
+    }
+
+    #[test]
+    fn from_set_ignores_unknown_names() {
+        assert_eq!(
+            TableFlags::from_set(&set(&["not_a_real_table"])),
+            TableFlags::empty()
+        );
+    }
+
+    #[test]
+    fn empty_config_writes_default_tables_but_not_opt_in_ones() {
+        let flags = TableFlags::empty();
+        assert_eq!(
+            filter_data(&flags, TableFlags::CURRENT_TOKEN_DATAS_V2, vec![1]),
+            vec![1]
+        );
+        assert!(filter_data(&flags, TableFlags::TOKEN_DATAS_V2, vec![1]).is_empty());
+        assert!(filter_data(&flags, TableFlags::FUNGIBLE_ASSET_BALANCES, vec![1]).is_empty());
+    }
+
+    #[test]
+    fn opting_into_a_historical_table_keeps_other_defaults_on() {
+        let flags = TableFlags::from_set(&set(&["token_datas_v2"]));
+        assert_eq!(
+            filter_data(&flags, TableFlags::TOKEN_DATAS_V2, vec![1]),
+            vec![1]
+        );
+        // Not named, but still written because no non-opt-in allowlist was given.
+        assert_eq!(
+            filter_data(&flags, TableFlags::CURRENT_TOKEN_DATAS_V2, vec![1]),
+            vec![1]
+        );
+        // A sibling opt-in table stays off.
+        assert!(filter_data(&flags, TableFlags::TOKEN_OWNERSHIPS_V2, vec![1]).is_empty());
+    }
+
+    #[test]
+    fn explicit_allowlist_still_excludes_unnamed_tables() {
+        let flags = TableFlags::from_set(&set(&["current_token_datas_v2", "token_datas_v2"]));
+        assert_eq!(
+            filter_data(&flags, TableFlags::CURRENT_TOKEN_DATAS_V2, vec![1]),
+            vec![1]
+        );
+        assert_eq!(
+            filter_data(&flags, TableFlags::TOKEN_DATAS_V2, vec![1]),
+            vec![1]
+        );
+        assert!(filter_data(&flags, TableFlags::CURRENT_TOKEN_OWNERSHIPS_V2, vec![1]).is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

These three tables already existed in `schema.rs` and their rows were already parsed in memory, but nothing ever wrote them to Postgres — only the parquet processors consumed them. `token_v2_extractor.rs` said so explicitly:

> Token v2 processor only writes to current tables. If you need to write to non-current tables, modify TokenV2Storer step to include the tables you want to write to.

This wires them into the Postgres write path, gated behind an opt-in config so existing deployments are unaffected.

| Table | Processor | What was missing |
|---|---|---|
| `fungible_asset_balances` | `fungible_asset_processor` | Storer discarded the data; model + insert query already existed |
| `token_datas_v2` | `token_v2_processor` | Insertable model, insert query, and plumbing |
| `token_ownerships_v2` | `token_v2_processor` | Insertable model, insert query, and plumbing |

## Changes

**Write path**
- `fungible_asset_storer.rs`: bind the balances element instead of discarding it as `_`, gate on `TableFlags::FUNGIBLE_ASSET_BALANCES`, and execute `insert_fungible_asset_balances_query` (which already existed but was dead code).
- New `PostgresTokenDataV2` / `PostgresTokenOwnershipV2` insertable models plus `From` impls. Note `owner_address` stays `Option<String>` on the historical ownership model, matching the nullable column — the `current_` variant flattens it to `String`.
- New `insert_token_datas_v2_query` / `insert_token_ownerships_v2_query`, both `on_conflict((transaction_version, write_set_change_index)).do_nothing()` since these are append-only.
- `token_v2_extractor.rs`: stop discarding `parse_v2_token`'s non-current outputs.

**Opt-in config**
- Adds `TableFlags::OPT_IN_ONLY`. These tables hold one row per write set change, so they grow far faster than their `current_` counterparts — writing them by default would change the storage profile of every existing deployment. They are now written only when named explicitly in `tables_to_write`.
- Naming an opt-in table does **not** turn `tables_to_write` into an allowlist for everything else. Without that, enabling a historical table would silently switch off every table that used to be written by default.
- Both extractors take `TableFlags` and skip building the rows entirely when the table is off. Converting them and letting the storer discard them would keep up to `channel_size` batches of dead rows resident in the channel — so the opt-in has to be honoured before the channel, not after it.
- The predicate lives in `table_flags::should_write`, shared by the extractors and `filter_data`.

```yaml
processor_config:
  type: token_v2_processor
  tables_to_write:
    - token_datas_v2
    - token_ownerships_v2
```

**Observability**
- `tables_to_write` is easy to get subtly wrong: an allowlist silently suppresses everything it omits, and a name belonging to a different processor suppresses everything. Each processor now logs its effective selection at startup via `TableFlags::describe_effective`, so the outcome is visible rather than inferred from missing rows.

**Drive-by fix**
- `TableFlags::from_set` called bitflags' `from_name`, which matches the uppercase constant name exactly — so a natural config entry like `token_datas_v2` silently matched nothing and was dropped. Names are now matched case-insensitively, and unrecognized entries log a warning instead of vanishing. Worth flagging for anyone whose config lists lowercase table names today: it has been a no-op, and this change makes it take effect.

Behavior is unchanged for configs that don't name an opt-in table.

## Caveats when enabling these tables

Documented in the README alongside the config reference:

- **No backfill.** Rows only start at the version the processor is on when the flag is enabled, and `ON CONFLICT ... DO NOTHING` means replaying earlier versions won't fill in history.
- **`token_datas_v2.is_deleted_v2` is always `NULL`.** The raw `TokenDataV2` sets `None` at every construction site; burns are recorded only in `current_token_datas_v2`, with no historical row emitted. Don't use `token_datas_v2` alone to decide whether a token still exists.
- **The `legacy_migration_v1` views stay incomplete.** `coin_balances` reads `fungible_asset_balances` directly, so it starts returning *partial* history — which reads as data rather than as "history unavailable". The token views join `collections_v2`, which no Postgres processor writes, so they keep returning zero rows.
- **Supporting indexes are commented out** in `2024-05-22-200847_add_v1_migration_views/up.sql` (they need `CONCURRENTLY`, outside diesel). Create them before querying at scale.

No migration needed — all three tables are already created by existing migrations. The parquet path is untouched; it uses `add_to_map_if_opted_in_for_backfill`, not `filter_data`.

## Testing

- `cargo check -p processor --all-targets`, `cargo clippy -p processor --all-targets`, and nightly `rustfmt --check` all clean.
- 6 new unit tests covering the opt-in semantics and the startup summary, plus one that parses the exact YAML shape documented in the config comments so the example can't drift from the code. All 11 pass.
- Two pre-existing failures in `parquet_buffer_step` (`Failed to create GCS client config: missing field access_token`) reproduce on `main` without these changes; they need GCP credentials.
- Not run: the integration tests, which need a live Postgres. They use an empty `tables_to_write`, so existing fixtures stay valid — but they give no coverage of the new tables and would need regenerating for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)