### PR TITLE
remove runs-on.yml from workflows directory

### DIFF
--- a/.github/workflows/runs-on.yml
+++ b/.github/workflows/runs-on.yml
@@ -1,3 +1,0 @@
-# Inherit from the internal-ops repo
-# https://runs-on.com/configuration/repo-config/
-_extends: internal-ops


### PR DESCRIPTION
## Summary
- Removes `.github/workflows/runs-on.yml` which was causing CI failures after merges to main
- The file is a runs-on.com config file, not a valid GitHub Actions workflow — GitHub Actions rejects it with `Unexpected value '_extends'`
- Safe to remove: all jobs already use `ubuntu-latest` (standard GitHub-hosted runners)

## Test plan
- [ ] Verify CI passes after merge without the invalid workflow file error

🤖 Generated with [Claude Code](https://claude.com/claude-code)