### PR TITLE
Use stable toolchain for cargo xclippy in lint script

### DIFF
--- a/scripts/rust_lint.sh
+++ b/scripts/rust_lint.sh
@@ -25,7 +25,10 @@ fi
 set -e
 set -x
 
-cargo +nightly xclippy
+# Run clippy on the pinned STABLE toolchain (from rust-toolchain.toml), NOT
+# nightly. Latest nightly makes Infallible an alias of !, which breaks
+# allocative (impl Allocative for both). Stable clippy matches the build toolchain.
+cargo xclippy
 
 # We require the nightly build of cargo fmt
 # to provide stricter rust formatting.


### PR DESCRIPTION
## Problem

Lint CI runs `cargo +nightly xclippy`. Current nightlies make `Infallible` an alias of `!`, so `allocative` fails with:

```
error[E0119]: conflicting implementations of trait `Allocative` for type `!`
```

That turns every open PR red on the `Rust` check. Not caused by those PR diffs.

## Fix

One-line change in `scripts/rust_lint.sh`: `cargo +nightly xclippy` → `cargo xclippy` (pinned stable from `rust-toolchain.toml`). Keep `cargo +nightly fmt`.

Same approach as [aptos-labs/aptos-indexer-processors-v2#192](https://github.com/aptos-labs/aptos-indexer-processors-v2/pull/192) for the lint half (we are not dropping `allocative` here).

## Test plan

- [ ] Lint workflow on this PR: `Rust` job should get past clippy (fmt still uses nightly)
- [ ] Confirm failure mode was allocative, not this repo’s code