### PR TITLE
CI: stable xclippy + bookworm Docker bases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
         cmake \
         curl \
         clang \
+        make \
         git \
         pkg-config \
         libssl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,24 @@
 
 # Stage 1: Build the binary
 
-FROM rust:slim-bullseye as builder
+FROM rust:slim-bookworm AS builder
 
 WORKDIR /app
 
 COPY --link . /app
 
-RUN for i in 1 2 3; do apt-get update && apt-get install --fix-missing -y cmake curl clang git pkg-config libssl-dev libdw-dev libpq-dev lld && break || sleep 10; done
+RUN apt-get update \
+    && apt-get install --no-install-recommends --fix-missing -y \
+        cmake \
+        curl \
+        clang \
+        git \
+        pkg-config \
+        libssl-dev \
+        libdw-dev \
+        libpq-dev \
+        lld \
+    && rm -rf /var/lib/apt/lists/*
 ENV CARGO_NET_GIT_FETCH_WITH_CLI true
 # TODO: Fix this with real processors.
 RUN cargo build --locked --release -p processor && ls -lah target/release/
@@ -24,19 +35,19 @@ ENV GIT_SHA ${GIT_SHA}
 
 # Stage 2: Create the final image
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY --from=builder /usr/local/bin/processor /usr/local/bin
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install --no-install-recommends --fix-missing -y \
-        libssl1.1 \
+        libssl3 \
         ca-certificates \
         net-tools \
         tcpdump \
         iproute2 \
-        netcat \
+        netcat-openbsd \
         libdw-dev \
         libpq-dev \
         curl

--- a/Dockerfile.address-reputation-api
+++ b/Dockerfile.address-reputation-api
@@ -2,13 +2,24 @@
 
 # Stage 1: Build the binary
 
-FROM rust:slim-bullseye as builder
+FROM rust:slim-bookworm AS builder
 
 WORKDIR /app
 
 COPY --link . /app
 
-RUN for i in 1 2 3; do apt-get update && apt-get install --fix-missing -y cmake curl clang git pkg-config libssl-dev libdw-dev libpq-dev lld && break || sleep 10; done
+RUN apt-get update \
+    && apt-get install --no-install-recommends --fix-missing -y \
+        cmake \
+        curl \
+        clang \
+        git \
+        pkg-config \
+        libssl-dev \
+        libdw-dev \
+        libpq-dev \
+        lld \
+    && rm -rf /var/lib/apt/lists/*
 ENV CARGO_NET_GIT_FETCH_WITH_CLI true
 RUN cargo build --locked --release -p address-reputation-api && ls -lah target/release/
 RUN cp target/release/address-reputation-api /usr/local/bin
@@ -23,19 +34,19 @@ ENV GIT_SHA ${GIT_SHA}
 
 # Stage 2: Create the final image
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY --from=builder /usr/local/bin/address-reputation-api /usr/local/bin
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install --no-install-recommends --fix-missing -y \
-        libssl1.1 \
+        libssl3 \
         ca-certificates \
         net-tools \
         tcpdump \
         iproute2 \
-        netcat \
+        netcat-openbsd \
         libdw-dev \
         libpq-dev \
         curl

--- a/Dockerfile.address-reputation-api
+++ b/Dockerfile.address-reputation-api
@@ -13,6 +13,7 @@ RUN apt-get update \
         cmake \
         curl \
         clang \
+        make \
         git \
         pkg-config \
         libssl-dev \

--- a/scripts/rust_lint.sh
+++ b/scripts/rust_lint.sh
@@ -25,7 +25,10 @@ fi
 set -e
 set -x
 
-cargo +nightly xclippy
+# Run clippy on the pinned STABLE toolchain (from rust-toolchain.toml), NOT
+# nightly. Latest nightly makes Infallible an alias of !, which breaks
+# allocative (impl Allocative for both). Stable clippy matches the build toolchain.
+cargo xclippy
 
 # We require the nightly build of cargo fmt
 # to provide stricter rust formatting.


### PR DESCRIPTION
## Problem

1. **Lint:** `cargo +nightly xclippy` breaks on `allocative` (`Infallible` aliased to `!` on current nightlies).
2. **Build / BuildAddressReputationApi:** `rust:slim-bullseye` apt hits expired `bullseye-security` InRelease; the retry loop no-ops so `git` never installs; `diesel-async` (git dep) fails to fetch.

## Fix

1. `scripts/rust_lint.sh`: `cargo +nightly xclippy` → `cargo xclippy` (stable from `rust-toolchain.toml`). Keep nightly for `fmt`.
2. `Dockerfile` + `Dockerfile.address-reputation-api`: bullseye → bookworm, `libssl1.1` → `libssl3`, `netcat` → `netcat-openbsd`, builder apt fails hard (no silent retry swallow).

## Test plan

- [ ] Lint: `Rust` past clippy
- [ ] Docker Build / BuildAddressReputationApi green (`git` present, diesel-async clones)
- [ ] Commits verified